### PR TITLE
issues 34 and 48 changes

### DIFF
--- a/src/lib/PatientSearch.js
+++ b/src/lib/PatientSearch.js
@@ -521,25 +521,16 @@ export default class PatientSearch {
 
       // sort ------------------------------------------------------------
       if (this.sort) {
+        let fullSortString = "";
         String(this.sort)
           .split(",")
           .forEach((token) => {
-            if (token.indexOf("-") === 0) {
-              params.push({
-                name: "_sort",
-                value: token,
-              });
-            } else {
-              params.push({
-                name: "_sort",
-                value: token,
-              });
-            }
+            fullSortString += token + ",";
           });
-        // params.push({
-        //     name : "_sort",
-        //     value: this.sort
-        // })
+        params.push({
+          name: "_sort",
+          value: fullSortString.substring(0, fullSortString.length - 1),
+        });
       }
 
       if (!this.params._id) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -114,9 +114,11 @@ export function base64decodeResource(res) {
   let decodedResource = JSON.parse(JSON.stringify(res));
   switch (res.resourceType) {
     case "DiagnosticReport":
-      decodedResource.presentedForm[0].data = atob(
-        decodedResource.presentedForm[0].data
-      );
+      if (typeof decodedResource.presentedForm != "undefined") {
+        decodedResource.presentedForm.forEach((item) => {
+          item.data = atob(item.data);
+        });
+      }
       break;
     case "Condition":
     case "AllergyIntolerance":
@@ -571,7 +573,9 @@ function getInsightEntryDetails(item) {
         evidenceDetailDecoded,
         "spellCorrectedText"
       );
-      result.evidenceDetail = spellCorrectedText[0].correctedText;
+      if (spellCorrectedText != undefined) {
+        result.evidenceDetail = spellCorrectedText[0].correctedText;
+      }
     }
   }
   return result;


### PR DESCRIPTION
Issue 34 - Fixed multi-sort option by handling multiple sort options by passing to _sort parameter as comma delimited list.
Issue 48 - Handled - 1) where presentedForm element of diagnostic report can have 0...* cardinality and 2) where evaluated_output attribute for condition enriched by QUICKUMLS does not contain 'CorrectedText' attribute when base64 decoded. 
@ranum (& @rguderian) - fixes demo-ed on -> https://paul-dev.wh-health-patterns.dev.watson-health.ibm.com/patient-browser/#/ currently